### PR TITLE
PR: Make CoreDNS Configuration Persistent & Include Host Entries

### DIFF
--- a/infrastructure/dev/compute-plane/README.md
+++ b/infrastructure/dev/compute-plane/README.md
@@ -10,8 +10,7 @@ export region_plain=aws-eu-east-2
 export identity_subdomain=aws-robolaunch-server
 export root_domain=robolaunch.internal
 export org_client_secret=lMVe8sMXCdv6KxOTwHrVcJon9r5kRyKy
-export github_pat=<GITHUB-PERSONAL-ACCESS-TOKEN>
-
+export github_pat="<GITHUB-PERSONAL-ACCESS-TOKEN>"
 # optional parameters
 export self_signed_cert=true
 export mig_strategy=mixed

--- a/infrastructure/dev/compute-plane/README.md
+++ b/infrastructure/dev/compute-plane/README.md
@@ -11,9 +11,14 @@ export identity_subdomain=aws-robolaunch-server
 export root_domain=robolaunch.internal
 export org_client_secret=lMVe8sMXCdv6KxOTwHrVcJon9r5kRyKy
 export github_pat=<GITHUB-PERSONAL-ACCESS-TOKEN>
-export self_signed_cert=true # optional
-export mig_strategy=mixed # optional
-export available_mig_instance=mig-1g.6gb # optional
-export tz_continent=Europe # optional
-export tz_city=Istanbul # optional
+
+# optional parameters
+export self_signed_cert=true
+export mig_strategy=mixed
+export available_mig_instance=mig-1g.6gb
+export tz_continent=Europe
+export tz_city=Istanbul
+export control_plane_host_entry="<IP>   <ENTRIES>"
+export compute_plane_host_entry="<IP>   <ENTRIES>"
+export control_compute_plane_host_entry="<IP>   <ENTRIES>"
 ```

--- a/infrastructure/dev/compute-plane/run.sh
+++ b/infrastructure/dev/compute-plane/run.sh
@@ -516,6 +516,20 @@ servers:
       -f $DIR_PATH/coredns/values.yaml
 	sleep 2;
 }
+add_host_entries () {
+    # [Distributed Setup] add host for control plane
+    if [[ -n "${CONTROL_PLANE_HOST_ENTRY}" && ! $(grep -q "$CONTROL_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
+        echo $CONTROL_PLANE_HOST_ENTRY >> /etc/hosts;
+    fi
+    # [Distributed Setup] add host for compute plane
+    if [[ -n "${COMPUTE_PLANE_HOST_ENTRY}" && ! $(grep -q "$COMPUTE_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
+        echo $COMPUTE_PLANE_HOST_ENTRY >> /etc/hosts;
+    fi
+    # [Unified Setup] add host for control & compute plane
+    if [[ -n "${CONTROL_COMPUTE_PLANE_HOST_ENTRY}" && ! $(grep -q "$CONTROL_COMPUTE_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
+        echo $CONTROL_COMPUTE_PLANE_HOST_ENTRY >> /etc/hosts;
+    fi
+}
 install_coredns_as_manifest () {
     # forward to /etc/resolv.conf
     sed -i "s#<COREDNS-FORWARD>#/etc/resolv.conf#g" $DIR_PATH/coredns/coredns.yaml;
@@ -806,6 +820,8 @@ print_global_log "Setting up NVIDIA container runtime...";
 (set_up_nvidia_container_runtime)
 print_global_log "Copying Start Script...";
 (copy_start_script)
+print_global_log "Adding host entries...";
+(add_host_entries)
 print_global_log "Setting up k3s cluster...";
 (set_up_k3s)
 print_global_log "Checking cluster health...";

--- a/infrastructure/dev/compute-plane/run.sh
+++ b/infrastructure/dev/compute-plane/run.sh
@@ -41,6 +41,9 @@ SELF_SIGNED_CERT=$self_signed_cert
 TZ_CONTINENT=$tz_continent
 TZ_CITY=$tz_city
 GITHUB_PATH=$github_pat
+CONTROL_PLANE_HOST_ENTRY=$control_plane_host_entry
+COMPUTE_PLANE_HOST_ENTRY=$compute_plane_host_entry
+CONTROL_COMPUTE_PLANE_HOST_ENTRY=$control_compute_plane_host_entry
 if [[ -z "${available_mig_instance}" ]]; then
     print_log "Skipping MIG configuration..."
 else

--- a/infrastructure/dev/compute-plane/run.sh
+++ b/infrastructure/dev/compute-plane/run.sh
@@ -519,15 +519,15 @@ servers:
 add_host_entries () {
     # [Distributed Setup] add host for control plane
     if [[ -n "${CONTROL_PLANE_HOST_ENTRY}" && ! $(grep -q "$CONTROL_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
-        echo $CONTROL_PLANE_HOST_ENTRY >> /etc/hosts;
+        sed -i "2i$CONTROL_PLANE_HOST_ENTRY" /etc/hosts;
     fi
     # [Distributed Setup] add host for compute plane
     if [[ -n "${COMPUTE_PLANE_HOST_ENTRY}" && ! $(grep -q "$COMPUTE_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
-        echo $COMPUTE_PLANE_HOST_ENTRY >> /etc/hosts;
+        sed -i "2i$COMPUTE_PLANE_HOST_ENTRY" /etc/hosts;
     fi
     # [Unified Setup] add host for control & compute plane
     if [[ -n "${CONTROL_COMPUTE_PLANE_HOST_ENTRY}" && ! $(grep -q "$CONTROL_COMPUTE_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
-        echo $CONTROL_COMPUTE_PLANE_HOST_ENTRY >> /etc/hosts;
+        sed -i "2i$CONTROL_COMPUTE_PLANE_HOST_ENTRY" /etc/hosts;
     fi
 }
 install_coredns_as_manifest () {

--- a/infrastructure/dev/compute-plane/run.sh
+++ b/infrastructure/dev/compute-plane/run.sh
@@ -37,10 +37,12 @@ OIDC_ORGANIZATION_CLIENT_SECRET=$org_client_secret
 COOKIE_SECRET=MFlZN1J5eitIdUplckJLaW55YlF6UjVlQ3lneFJBcEU=
 DOMAIN=$root_domain
 SERVER_URL=$CLOUD_INSTANCE.$DOMAIN
+GITHUB_PATH=$github_pat
+
+############## Optional Parameters ##############
 SELF_SIGNED_CERT=$self_signed_cert
 TZ_CONTINENT=$tz_continent
 TZ_CITY=$tz_city
-GITHUB_PATH=$github_pat
 CONTROL_PLANE_HOST_ENTRY=$control_plane_host_entry
 COMPUTE_PLANE_HOST_ENTRY=$compute_plane_host_entry
 CONTROL_COMPUTE_PLANE_HOST_ENTRY=$control_compute_plane_host_entry
@@ -54,6 +56,7 @@ if [[ -z "${mig_strategy}" ]]; then
 else
     MIG_STRATEGY=$mig_strategy
 fi
+#################################################
 
 BLUE='\033[0;34m';
 GREEN='\033[0;32m';
@@ -514,7 +517,7 @@ servers:
 	sleep 2;
 }
 edit_coredns () {
-    # add custom config for CoreDNS
+    
 }
 install_metrics_server () {
     echo "image:

--- a/infrastructure/dev/compute-plane/run.sh
+++ b/infrastructure/dev/compute-plane/run.sh
@@ -260,6 +260,7 @@ set_up_k3s () {
           --service-cidr=$DESIRED_SERVICE_CIDR \
           --cluster-domain=$CLUSTER_DOMAIN.local \
           --disable-network-policy \
+          --disable=coredns \
           --disable=traefik \
           --disable=local-storage \
           --disable=metrics-server \
@@ -515,7 +516,7 @@ servers:
       -f $DIR_PATH/coredns/values.yaml
 	sleep 2;
 }
-edit_coredns () {
+install_coredns_as_manifest () {
     # forward to /etc/resolv.conf
     sed -i "s#<COREDNS-FORWARD>#/etc/resolv.conf#g" $DIR_PATH/coredns/coredns.yaml;
     sed -i "s#<CLOUD-INSTANCE>#$CLOUD_INSTANCE#g" $DIR_PATH/coredns/coredns.yaml;
@@ -539,7 +540,7 @@ edit_coredns () {
         sed -i "s/<CONTROL-COMPUTE-PLANE-HOST-ENTRY>/$CONTROL_COMPUTE_PLANE_HOST_ENTRY/g" $DIR_PATH/coredns/coredns.yaml;
     fi
 
-    cp $DIR_PATH/coredns/coredns.yaml /var/lib/rancher/k3s/server/manifests/coredns_override.yaml;
+    kubectl apply -f $DIR_PATH/coredns/coredns.yaml;
 }
 install_metrics_server () {
     echo "image:
@@ -817,8 +818,8 @@ print_global_log "Creating super admin crb...";
 (create_super_admin_crb)
 # print_global_log "Installing coredns...";
 # (install_coredns)
-print_global_log "Editing coredns...";
-(edit_coredns)
+print_global_log "Installing coredns...";
+(install_coredns_as_manifest)
 print_global_log "Installing metrics-server...";
 (install_metrics_server)
 print_global_log "Installing ingress...";

--- a/infrastructure/dev/compute-plane/run.sh
+++ b/infrastructure/dev/compute-plane/run.sh
@@ -518,15 +518,15 @@ servers:
 }
 add_host_entries () {
     # [Distributed Setup] add host for control plane
-    if [[ -n "${CONTROL_PLANE_HOST_ENTRY}" && ! $(grep -q "$CONTROL_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
+    if [[ -n "${CONTROL_PLANE_HOST_ENTRY}" && $(grep -L "$CONTROL_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
         sed -i "2i$CONTROL_PLANE_HOST_ENTRY" /etc/hosts;
     fi
     # [Distributed Setup] add host for compute plane
-    if [[ -n "${COMPUTE_PLANE_HOST_ENTRY}" && ! $(grep -q "$COMPUTE_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
+    if [[ -n "${COMPUTE_PLANE_HOST_ENTRY}" && $(grep -L "$COMPUTE_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
         sed -i "2i$COMPUTE_PLANE_HOST_ENTRY" /etc/hosts;
     fi
     # [Unified Setup] add host for control & compute plane
-    if [[ -n "${CONTROL_COMPUTE_PLANE_HOST_ENTRY}" && ! $(grep -q "$CONTROL_COMPUTE_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
+    if [[ -n "${CONTROL_COMPUTE_PLANE_HOST_ENTRY}" && $(grep -L "$CONTROL_COMPUTE_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
         sed -i "2i$CONTROL_COMPUTE_PLANE_HOST_ENTRY" /etc/hosts;
     fi
 }

--- a/infrastructure/dev/compute-plane/run.sh
+++ b/infrastructure/dev/compute-plane/run.sh
@@ -516,6 +516,10 @@ servers:
 	sleep 2;
 }
 edit_coredns () {
+    # forward to /etc/resolv.conf
+    sed -i "s#<COREDNS-FORWARD>#/etc/resolv.conf#g" $DIR_PATH/coredns/coredns.yaml;
+    sed -i "s#<CLOUD-INSTANCE>#$CLOUD_INSTANCE#g" $DIR_PATH/coredns/coredns.yaml;
+
     # [Distributed Setup] add host for control plane
     if [[ -z "${CONTROL_PLANE_HOST_ENTRY}" ]]; then
         sed -i '/<CONTROL-PLANE-HOST-ENTRY>/d' $DIR_PATH/coredns/coredns.yaml
@@ -534,8 +538,6 @@ edit_coredns () {
     else
         sed -i "s/<CONTROL-COMPUTE-PLANE-HOST-ENTRY>/$CONTROL_COMPUTE_PLANE_HOST_ENTRY/g" $DIR_PATH/coredns/coredns.yaml;
     fi
-    # forward to /etc/resolv.conf
-    sed -i "s/<COREDNS-FORWARD>//etc/resolv.conf/g" $DIR_PATH/coredns/coredns.yaml;
 
     cp $DIR_PATH/coredns/coredns.yaml /var/lib/rancher/k3s/server/manifests/coredns_override.yaml;
 }

--- a/infrastructure/dev/compute-plane/run.sh
+++ b/infrastructure/dev/compute-plane/run.sh
@@ -195,6 +195,7 @@ create_directories () {
     mkdir -p $DIR_PATH/filemanager;
 
     wget --header "Authorization: token $GITHUB_PAT" -P $DIR_PATH/coredns https://github.com/robolaunch/on-premise/releases/download/$PLATFORM_VERSION/coredns-1.24.5.tgz
+    wget --header "Authorization: token $GITHUB_PAT" -P $DIR_PATH/coredns https://github.com/robolaunch/on-premise/releases/download/$PLATFORM_VERSION/coredns.yaml
     wget --header "Authorization: token $GITHUB_PAT" -P $DIR_PATH/metrics-server https://github.com/robolaunch/on-premise/releases/download/$PLATFORM_VERSION/metrics-server-3.11.0.tgz
     wget --header "Authorization: token $GITHUB_PAT" -P $DIR_PATH/openebs https://github.com/robolaunch/on-premise/releases/download/$PLATFORM_VERSION/openebs-3.8.0.tgz
     wget --header "Authorization: token $GITHUB_PAT" -P $DIR_PATH/nvidia-device-plugin https://github.com/robolaunch/on-premise/releases/download/$PLATFORM_VERSION/nvidia-device-plugin-0.14.2.tgz
@@ -511,6 +512,9 @@ servers:
       --create-namespace \
       -f $DIR_PATH/coredns/values.yaml
 	sleep 2;
+}
+edit_coredns () {
+    # add custom config for CoreDNS
 }
 install_metrics_server () {
     echo "image:

--- a/infrastructure/dev/one-cluster/README.md
+++ b/infrastructure/dev/one-cluster/README.md
@@ -10,8 +10,7 @@ export region_plain=aws-eu-east-2
 export identity_subdomain=aws-robolaunch-server
 export root_domain=robolaunch.internal
 export org_client_secret=lMVe8sMXCdv6KxOTwHrVcJon9r5kRyKy
-export github_pat=<GITHUB-PERSONAL-ACCESS-TOKEN>
-
+export github_pat="<GITHUB-PERSONAL-ACCESS-TOKEN>"
 # optional parameters
 export self_signed_cert=true
 export mig_strategy=mixed

--- a/infrastructure/dev/one-cluster/README.md
+++ b/infrastructure/dev/one-cluster/README.md
@@ -9,10 +9,16 @@ export cloud_instance=aws-dev-01-5f6s87
 export region_plain=aws-eu-east-2
 export identity_subdomain=aws-robolaunch-server
 export root_domain=robolaunch.internal
+export org_client_secret=lMVe8sMXCdv6KxOTwHrVcJon9r5kRyKy
 export github_pat=<GITHUB-PERSONAL-ACCESS-TOKEN>
-export self_signed_cert=true # optional
-export mig_strategy=mixed # optional
-export available_mig_instance=mig-1g.6gb # optional
-export tz_continent=Europe # optional
-export tz_city=Istanbul # optional
+
+# optional parameters
+export self_signed_cert=true
+export mig_strategy=mixed
+export available_mig_instance=mig-1g.6gb
+export tz_continent=Europe
+export tz_city=Istanbul
+export control_plane_host_entry="<IP>   <ENTRIES>"
+export compute_plane_host_entry="<IP>   <ENTRIES>"
+export control_compute_plane_host_entry="<IP>   <ENTRIES>"
 ```

--- a/infrastructure/dev/one-cluster/run.sh
+++ b/infrastructure/dev/one-cluster/run.sh
@@ -516,6 +516,20 @@ servers:
       -f $DIR_PATH/coredns/values.yaml
 	sleep 2;
 }
+add_host_entries () {
+    # [Distributed Setup] add host for control plane
+    if [[ -n "${CONTROL_PLANE_HOST_ENTRY}" && ! $(grep -q "$CONTROL_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
+        echo $CONTROL_PLANE_HOST_ENTRY >> /etc/hosts;
+    fi
+    # [Distributed Setup] add host for compute plane
+    if [[ -n "${COMPUTE_PLANE_HOST_ENTRY}" && ! $(grep -q "$COMPUTE_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
+        echo $COMPUTE_PLANE_HOST_ENTRY >> /etc/hosts;
+    fi
+    # [Unified Setup] add host for control & compute plane
+    if [[ -n "${CONTROL_COMPUTE_PLANE_HOST_ENTRY}" && ! $(grep -q "$CONTROL_COMPUTE_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
+        echo $CONTROL_COMPUTE_PLANE_HOST_ENTRY >> /etc/hosts;
+    fi
+}
 install_coredns_as_manifest () {
     # forward to /etc/resolv.conf
     sed -i "s#<COREDNS-FORWARD>#/etc/resolv.conf#g" $DIR_PATH/coredns/coredns.yaml;
@@ -806,6 +820,8 @@ print_global_log "Setting up NVIDIA container runtime...";
 (set_up_nvidia_container_runtime)
 print_global_log "Copying Start Script...";
 (copy_start_script)
+print_global_log "Adding host entries...";
+(add_host_entries)
 print_global_log "Setting up k3s cluster...";
 (set_up_k3s)
 print_global_log "Checking cluster health...";

--- a/infrastructure/dev/one-cluster/run.sh
+++ b/infrastructure/dev/one-cluster/run.sh
@@ -519,15 +519,15 @@ servers:
 add_host_entries () {
     # [Distributed Setup] add host for control plane
     if [[ -n "${CONTROL_PLANE_HOST_ENTRY}" && ! $(grep -q "$CONTROL_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
-        echo $CONTROL_PLANE_HOST_ENTRY >> /etc/hosts;
+        sed -i "2i$CONTROL_PLANE_HOST_ENTRY" /etc/hosts;
     fi
     # [Distributed Setup] add host for compute plane
     if [[ -n "${COMPUTE_PLANE_HOST_ENTRY}" && ! $(grep -q "$COMPUTE_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
-        echo $COMPUTE_PLANE_HOST_ENTRY >> /etc/hosts;
+        sed -i "2i$COMPUTE_PLANE_HOST_ENTRY" /etc/hosts;
     fi
     # [Unified Setup] add host for control & compute plane
     if [[ -n "${CONTROL_COMPUTE_PLANE_HOST_ENTRY}" && ! $(grep -q "$CONTROL_COMPUTE_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
-        echo $CONTROL_COMPUTE_PLANE_HOST_ENTRY >> /etc/hosts;
+        sed -i "2i$CONTROL_COMPUTE_PLANE_HOST_ENTRY" /etc/hosts;
     fi
 }
 install_coredns_as_manifest () {

--- a/infrastructure/dev/one-cluster/run.sh
+++ b/infrastructure/dev/one-cluster/run.sh
@@ -37,10 +37,12 @@ OIDC_ORGANIZATION_CLIENT_SECRET=$org_client_secret
 COOKIE_SECRET=MFlZN1J5eitIdUplckJLaW55YlF6UjVlQ3lneFJBcEU=
 DOMAIN=$root_domain
 SERVER_URL=$CLOUD_INSTANCE.$DOMAIN
+GITHUB_PATH=$github_pat
+
+############## Optional Parameters ##############
 SELF_SIGNED_CERT=$self_signed_cert
 TZ_CONTINENT=$tz_continent
 TZ_CITY=$tz_city
-GITHUB_PATH=$github_pat
 CONTROL_PLANE_HOST_ENTRY=$control_plane_host_entry
 COMPUTE_PLANE_HOST_ENTRY=$compute_plane_host_entry
 CONTROL_COMPUTE_PLANE_HOST_ENTRY=$control_compute_plane_host_entry
@@ -54,6 +56,7 @@ if [[ -z "${mig_strategy}" ]]; then
 else
     MIG_STRATEGY=$mig_strategy
 fi
+#################################################
 
 BLUE='\033[0;34m';
 GREEN='\033[0;32m';
@@ -514,7 +517,7 @@ servers:
 	sleep 2;
 }
 edit_coredns () {
-    # add custom config for CoreDNS
+    
 }
 install_metrics_server () {
     echo "image:

--- a/infrastructure/dev/one-cluster/run.sh
+++ b/infrastructure/dev/one-cluster/run.sh
@@ -260,6 +260,7 @@ set_up_k3s () {
           --service-cidr=$DESIRED_SERVICE_CIDR \
           --cluster-domain=$CLUSTER_DOMAIN.local \
           --disable-network-policy \
+          --disable=coredns \
           --disable=traefik \
           --disable=local-storage \
           --disable=metrics-server \
@@ -515,7 +516,7 @@ servers:
       -f $DIR_PATH/coredns/values.yaml
 	sleep 2;
 }
-edit_coredns () {
+install_coredns_as_manifest () {
     # forward to /etc/resolv.conf
     sed -i "s#<COREDNS-FORWARD>#/etc/resolv.conf#g" $DIR_PATH/coredns/coredns.yaml;
     sed -i "s#<CLOUD-INSTANCE>#$CLOUD_INSTANCE#g" $DIR_PATH/coredns/coredns.yaml;
@@ -539,7 +540,7 @@ edit_coredns () {
         sed -i "s/<CONTROL-COMPUTE-PLANE-HOST-ENTRY>/$CONTROL_COMPUTE_PLANE_HOST_ENTRY/g" $DIR_PATH/coredns/coredns.yaml;
     fi
 
-    cp $DIR_PATH/coredns/coredns.yaml /var/lib/rancher/k3s/server/manifests/coredns_override.yaml;
+    kubectl apply -f $DIR_PATH/coredns/coredns.yaml;
 }
 install_metrics_server () {
     echo "image:
@@ -817,8 +818,8 @@ print_global_log "Creating super admin crb...";
 (create_super_admin_crb)
 # print_global_log "Installing coredns...";
 # (install_coredns)
-print_global_log "Editing coredns...";
-(edit_coredns)
+print_global_log "Installing coredns...";
+(install_coredns_as_manifest)
 print_global_log "Installing metrics-server...";
 (install_metrics_server)
 print_global_log "Installing ingress...";

--- a/infrastructure/dev/one-cluster/run.sh
+++ b/infrastructure/dev/one-cluster/run.sh
@@ -41,6 +41,9 @@ SELF_SIGNED_CERT=$self_signed_cert
 TZ_CONTINENT=$tz_continent
 TZ_CITY=$tz_city
 GITHUB_PATH=$github_pat
+CONTROL_PLANE_HOST_ENTRY=$control_plane_host_entry
+COMPUTE_PLANE_HOST_ENTRY=$compute_plane_host_entry
+CONTROL_COMPUTE_PLANE_HOST_ENTRY=$control_compute_plane_host_entry
 if [[ -z "${available_mig_instance}" ]]; then
     print_log "Skipping MIG configuration..."
 else
@@ -153,7 +156,7 @@ make_life_more_beautiful () {
 }
 opening () {
     apt-get update 2>/dev/null 1>/dev/null;
-    apt-get install -y figlet 2>/dev/null 1>/dev/null; 
+    apt-get install -y figlet 2>/dev/null 1>/dev/null;
     figlet 'robolaunch' -f slant;
 }
 check_if_root () {
@@ -239,7 +242,7 @@ curl -vk --resolve \$wan_ip:6443:127.0.0.1 https://\$wan_ip:6443/ping" > $DIR_PA
 }
 set_up_k3s () {
     CERT_ARG=""
-    
+
     if [[ -z "${SELF_SIGNED_CERT}" ]]; then
         CERT_ARG="";
     else
@@ -256,7 +259,6 @@ set_up_k3s () {
           --disable-network-policy \
           --disable=traefik \
           --disable=local-storage \
-          --disable=coredns \
           --disable=metrics-server \
           --pause-image=quay.io/robolaunchio/mirrored-pause:3.6 \
           --kube-apiserver-arg \
@@ -418,33 +420,33 @@ create_admin_crb () {
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: $ORGANIZATION-admin-role
-rules:                                                                                                                                                                                                    
-- apiGroups:         
-  - '*'              
-  resources:         
-  - nodes            
-  - namespaces       
-  - metricsexporters 
-  - secrets          
-  - roles            
-  - rolebindings     
-  - pods             
-  verbs:             
-  - get              
-  - list             
-- apiGroups:         
-  - '*'              
-  resources:         
-  - secrets          
-  - namespaces       
-  verbs:             
-  - create           
-- apiGroups:         
-  - '*'              
-  resources:         
-  - roles            
-  - rolebindings     
-  verbs:             
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - nodes
+  - namespaces
+  - metricsexporters
+  - secrets
+  - roles
+  - rolebindings
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - '*'
+  resources:
+  - secrets
+  - namespaces
+  verbs:
+  - create
+- apiGroups:
+  - '*'
+  resources:
+  - roles
+  - rolebindings
+  verbs:
   - create
   - bind
   - escalate
@@ -620,7 +622,7 @@ spec:
   ingressClassName: nginx" > proxy-ingress.yaml
     PROXY_INGRESS_INSTALL_SUCCEEDED="false"
     while [ "$PROXY_INGRESS_INSTALL_SUCCEEDED" != "true" ]
-    do 
+    do
         PROXY_INGRESS_INSTALL_SUCCEEDED="true"
         	kubectl create -f proxy-ingress.yaml || PROXY_INGRESS_INSTALL_SUCCEEDED="false";
         sleep 1;
@@ -639,7 +641,7 @@ install_operator_suite () {
       tag: v$ROBOT_OPERATOR_CHART_VERSION" > $DIR_PATH/robot-operator/values.yaml;
     RO_HELM_INSTALL_SUCCEEDED="false"
     while [ "$RO_HELM_INSTALL_SUCCEEDED" != "true" ]
-    do 
+    do
         RO_HELM_INSTALL_SUCCEEDED="true"
         helm upgrade -i \
             robot-operator $DIR_PATH/robot-operator/robot-operator-$ROBOT_OPERATOR_CHART_VERSION.tgz \
@@ -704,7 +706,7 @@ EOF
 }
 set_up_file_manager () {
     FILEBROWSER_CONFIG_PATH=/etc/robolaunch/filebrowser;
-    
+
     curl -fsSL https://raw.githubusercontent.com/tunahanertekin/filebrowser/master/get.sh | bash;
     mkdir -p /etc/robolaunch/services ${FILEBROWSER_CONFIG_PATH} /var/log/services/vdi;
     git clone https://github.com/robolaunch/file-manager-config ${FILEBROWSER_CONFIG_PATH}/filebrowser-config;
@@ -716,7 +718,7 @@ set_up_file_manager () {
         --branding.files ${FILEBROWSER_CONFIG_PATH}"/filebrowser-config/branding" \
         --branding.disableExternal \
         -d ${FILEBROWSER_CONFIG_PATH}/filebrowser-host.db;
-      
+
     chmod 1777 ${FILEBROWSER_CONFIG_PATH}/filebrowser-host.db /var/log/services ${FILEBROWSER_CONFIG_PATH}/filebrowser-config/;
     chown root ${FILEBROWSER_CONFIG_PATH}/filebrowser-host.db /var/log/services ${FILEBROWSER_CONFIG_PATH}/filebrowser-config/;
 
@@ -784,8 +786,8 @@ print_global_log "Creating admin crb...";
 (create_admin_crb)
 print_global_log "Creating super admin crb...";
 (create_super_admin_crb)
-print_global_log "Installing coredns...";
-(install_coredns)
+# print_global_log "Installing coredns...";
+# (install_coredns)
 print_global_log "Installing metrics-server...";
 (install_metrics_server)
 print_global_log "Installing ingress...";

--- a/infrastructure/dev/one-cluster/run.sh
+++ b/infrastructure/dev/one-cluster/run.sh
@@ -518,15 +518,15 @@ servers:
 }
 add_host_entries () {
     # [Distributed Setup] add host for control plane
-    if [[ -n "${CONTROL_PLANE_HOST_ENTRY}" && ! $(grep -q "$CONTROL_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
+    if [[ -n "${CONTROL_PLANE_HOST_ENTRY}" && $(grep -L "$CONTROL_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
         sed -i "2i$CONTROL_PLANE_HOST_ENTRY" /etc/hosts;
     fi
     # [Distributed Setup] add host for compute plane
-    if [[ -n "${COMPUTE_PLANE_HOST_ENTRY}" && ! $(grep -q "$COMPUTE_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
+    if [[ -n "${COMPUTE_PLANE_HOST_ENTRY}" && $(grep -L "$COMPUTE_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
         sed -i "2i$COMPUTE_PLANE_HOST_ENTRY" /etc/hosts;
     fi
     # [Unified Setup] add host for control & compute plane
-    if [[ -n "${CONTROL_COMPUTE_PLANE_HOST_ENTRY}" && ! $(grep -q "$CONTROL_COMPUTE_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
+    if [[ -n "${CONTROL_COMPUTE_PLANE_HOST_ENTRY}" && $(grep -L "$CONTROL_COMPUTE_PLANE_HOST_ENTRY" /etc/hosts) ]]; then
         sed -i "2i$CONTROL_COMPUTE_PLANE_HOST_ENTRY" /etc/hosts;
     fi
 }

--- a/infrastructure/dev/one-cluster/run.sh
+++ b/infrastructure/dev/one-cluster/run.sh
@@ -516,6 +516,10 @@ servers:
 	sleep 2;
 }
 edit_coredns () {
+    # forward to /etc/resolv.conf
+    sed -i "s#<COREDNS-FORWARD>#/etc/resolv.conf#g" $DIR_PATH/coredns/coredns.yaml;
+    sed -i "s#<CLOUD-INSTANCE>#$CLOUD_INSTANCE#g" $DIR_PATH/coredns/coredns.yaml;
+
     # [Distributed Setup] add host for control plane
     if [[ -z "${CONTROL_PLANE_HOST_ENTRY}" ]]; then
         sed -i '/<CONTROL-PLANE-HOST-ENTRY>/d' $DIR_PATH/coredns/coredns.yaml
@@ -534,8 +538,6 @@ edit_coredns () {
     else
         sed -i "s/<CONTROL-COMPUTE-PLANE-HOST-ENTRY>/$CONTROL_COMPUTE_PLANE_HOST_ENTRY/g" $DIR_PATH/coredns/coredns.yaml;
     fi
-    # forward to /etc/resolv.conf
-    sed -i "s/<COREDNS-FORWARD>//etc/resolv.conf/g" $DIR_PATH/coredns/coredns.yaml;
 
     cp $DIR_PATH/coredns/coredns.yaml /var/lib/rancher/k3s/server/manifests/coredns_override.yaml;
 }

--- a/infrastructure/dev/one-cluster/run.sh
+++ b/infrastructure/dev/one-cluster/run.sh
@@ -195,6 +195,7 @@ create_directories () {
     mkdir -p $DIR_PATH/filemanager;
 
     wget --header "Authorization: token $GITHUB_PAT" -P $DIR_PATH/coredns https://github.com/robolaunch/on-premise/releases/download/$PLATFORM_VERSION/coredns-1.24.5.tgz
+    wget --header "Authorization: token $GITHUB_PAT" -P $DIR_PATH/coredns https://github.com/robolaunch/on-premise/releases/download/$PLATFORM_VERSION/coredns.yaml
     wget --header "Authorization: token $GITHUB_PAT" -P $DIR_PATH/metrics-server https://github.com/robolaunch/on-premise/releases/download/$PLATFORM_VERSION/metrics-server-3.11.0.tgz
     wget --header "Authorization: token $GITHUB_PAT" -P $DIR_PATH/openebs https://github.com/robolaunch/on-premise/releases/download/$PLATFORM_VERSION/openebs-3.8.0.tgz
     wget --header "Authorization: token $GITHUB_PAT" -P $DIR_PATH/nvidia-device-plugin https://github.com/robolaunch/on-premise/releases/download/$PLATFORM_VERSION/nvidia-device-plugin-0.14.2.tgz
@@ -511,6 +512,9 @@ servers:
       --create-namespace \
       -f $DIR_PATH/coredns/values.yaml
 	sleep 2;
+}
+edit_coredns () {
+    # add custom config for CoreDNS
 }
 install_metrics_server () {
     echo "image:


### PR DESCRIPTION
# :herb: PR: Make CoreDNS Configuration Persistent & Include Host Entries

## Description

- CoreDNS is being deployed via manifests.
  - custom host entries are supported
  - CoreDNS forwarding to a custom nameserver is supported
- Host entries can be added to host's `/etc/hosts` file.

Closes #1 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How can it be tested?

Can be tested by setting one of these environment variables before executing installation script:
- `control_plane_host_entry`
- `compute_plane_host_entry`
- `control_compute_plane_host_entry`
